### PR TITLE
Reduce Docker image size

### DIFF
--- a/assets/entrypoint.sh
+++ b/assets/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-npm run prod &
+node build/server/main.js &
 
 # Wait for the server to start
 while ! nc -z localhost 8080; do

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,6 +1,7 @@
 ### Build server files
-FROM node:18 AS server-build
+FROM node:18-alpine AS server-build
 
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD="true"
 WORKDIR /app/server
 
 COPY ["server/package.json", "server/package-lock.json*", "./"]
@@ -12,13 +13,23 @@ COPY ./server .
 
 RUN npm run build
 
+# Prepare node_modules for docker
+RUN npm prune --production
+RUN apk update && \
+    apk add curl && \
+    curl -sf https://gobinaries.com/tj/node-prune | sh
+
+# The mv is a workaround for this - https://github.com/tj/node-prune/issues/63
+RUN mv node_modules/googleapis/build/src/apis/docs ./docs && \
+    node-prune --exclude "**/googleapis/**/docs/*.js" && \
+    mv ./docs node_modules/googleapis/build/src/apis/docs
+
 
 ### Build final image
 FROM node:18-alpine
 USER root
 
 ENV RUNNING_IN_DOCKER="true"
-ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD="true"
 WORKDIR /app/server
 
 # Install Chromium
@@ -26,11 +37,9 @@ RUN apk update && \
     apk add --no-cache nss udev ttf-freefont chromium nginx && \
     rm -rf /var/cache/apk/* /tmp/*
 
-COPY ["server/package.json", "server/package-lock.json*", "./"]
-RUN npm install --production && npm install -g pm2 --production
-
+COPY --from=server-build /app/server/node_modules ./node_modules
 COPY --from=server-build /app/server/build ./build
 
 EXPOSE 8080
 
-CMD [ "npm", "run", "prod" ]
+CMD [ "build/server/main.js" ]


### PR DESCRIPTION
Size reduced form 691MB to 577MB.
This was done in order to speed up cold start time on Google Cloud Run where the servers are deployed.