### PR TITLE
Reconnect WS on disconnect

### DIFF
--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -23,6 +23,10 @@ router.beforeEach(async (to, from) => {
   const response = await fetch("/api/status", { credentials: "include" });
   const status: SessionStatus = await response.json();
 
+  // Make sure websocket is initialized.
+  //  This is done on every request to make sure the server didn't discconect in the meantime.
+  initWs();
+
   if (["/sync", "/gauth"].includes(to.path) && !status.whatsappConnected)
     router.push("/");
   else if (to.path === "/sync" && !status.googleConnected)
@@ -32,5 +36,4 @@ router.beforeEach(async (to, from) => {
   else if (to.path === "/gauth" && status.googleConnected) router.push("/sync");
 });
 
-initWs();
 createApp(App).use(router).mount("#app");

--- a/web/src/services/ws.ts
+++ b/web/src/services/ws.ts
@@ -5,6 +5,10 @@ export let WS: WebSocket;
 let eventHandlers: { [eventType: string]: HandlerFunction } = {};
 
 export async function initWs(): Promise<void> {
+  if (WS && [WebSocket.OPEN, WebSocket.CONNECTING].includes(WS.readyState)) {
+    return;
+  }
+
   // An empty request is made to the server because without it on the first connection
   //  the websocket receives a different session id, causing the app to hang.
   await fetch("/api/", { credentials: "include" });


### PR DESCRIPTION
Currently in some cases if the server resets while the page is open, the WS isn't automatically reconnected.
This PR should fix this issue in most cases.