### PR TITLE
Remove saving of contact name

### DIFF
--- a/server/src/gapi.ts
+++ b/server/src/gapi.ts
@@ -45,7 +45,6 @@ export async function listContacts(
         (connection) =>
           <SimpleContact>{
             id: connection.resourceName,
-            name: connection.names![0].displayName,
             numbers: connection
               .phoneNumbers!.filter((phoneNumber) => phoneNumber.canonicalForm)
               .map((phoneNumber) =>

--- a/server/src/interfaces.ts
+++ b/server/src/interfaces.ts
@@ -2,5 +2,4 @@ export interface SimpleContact {
   id: string;
   numbers: string[];
   hasPhoto: boolean;
-  name?: string;
 }

--- a/server/src/whatsapp.ts
+++ b/server/src/whatsapp.ts
@@ -46,7 +46,6 @@ export async function loadContacts(
         <SimpleContact>{
           id: contact.id._serialized,
           numbers: [contact.number],
-          name: contact.name,
         }
     );
 


### PR DESCRIPTION
Cases where a Google contact had a phone number but no display name caused the backend to crash.
Since the contact names weren't actually in use (and just stored), there's no harm in removing them.
This should solve the issue, and a possible fix for #20.