### PR TITLE
Fix TypeScript Error in src/main.ts

### DIFF
--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -55,14 +55,22 @@ router.beforeEach(
   }
 );
 
+let currentRoute: RouteLocationNormalized;
+
+router.afterEach((to: RouteLocationNormalized) => {
+  // This is run after each navigation, including the initial navigation.
+  currentRoute = to;
+});
+
 const vueTagSettings = {
-  pageTrackerTemplate(to: RouteLocationNormalized) {
+  pageTrackerTemplate: () => {
     return {
-      page_title: to.path,
-      page_path: to.path,
+      page_title: currentRoute.path,
+      page_path: currentRoute.path,
     };
   },
   config: { id: "G-4PJJZRPWG4" },
 };
+
 
 createApp(App).use(router).use(VueGtag, vueTagSettings, router).mount("#app");


### PR DESCRIPTION
This PR resolves the TypeScript error encountered during the Docker build process as reported in issue #101.

The issue was due to a type mismatch between the `pageTrackerTemplate` function and the `PluginOptions` type in the `src/main.ts` file. The `pageTrackerTemplate` function was expecting no arguments and a return type of `PageView`, but was provided a function that takes a `RouteLocationNormalized` argument and returns an object with `page_title` and `page_path`.

I have corrected this mismatch, and the Docker build process now completes successfully. Please review the changes and let me know if there are any concerns.

Fixes #101.
