### PR TITLE
Update Dockerfile to handle line endings and improve build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,10 @@ RUN apk update && \
 
 COPY ./assets/nginx.conf /etc/nginx/nginx.conf
 COPY ./assets/entrypoint.sh .
+# Install dos2unix, convert line endings of entrypoint.sh, and then remove dos2unix
+RUN apk add --no-cache dos2unix && \
+    dos2unix entrypoint.sh && \
+    apk del dos2unix
 RUN chmod 755 entrypoint.sh
 
 COPY --from=web-build /app/web/dist /var/www/html


### PR DESCRIPTION
Hi,

This pull request updates the Dockerfile for the whatsapp-contact-sync project to address an issue with line endings in the entrypoint.sh script. The problem was causing syntax errors when running the Docker container due to different line endings between Windows and Unix systems.

To resolve this, the Dockerfile now includes the installation of dos2unix and the conversion of line endings in the entrypoint.sh script during the image build process. After converting the line endings, the dos2unix tool is removed from the image to keep the size small.

Please review and merge this pull request if it meets the project's requirements.

Thank you!