### PR TITLE
Update GitHub button width in Header.vue

### DIFF
--- a/web/src/components/Header.vue
+++ b/web/src/components/Header.vue
@@ -21,7 +21,7 @@ export default defineComponent({
         src="https://ghbtns.com/github-btn.html?user=guyzyl&repo=whatsapp-contact-sync&type=star&count=true&size=large"
         frameborder="0"
         scrolling="0"
-        width="130"
+        width="140"
         height="30"
         title="GitHub"
       ></iframe>


### PR DESCRIPTION
The number of stars is hidden since the the width of the button is too narrow.
This is not the first time this needed to be fixed, so I gave it an extra 10px with the hopes that I won't have to change this again in the near future.