### PR TITLE
Bump Node base image to v22 in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ### Build web files
-FROM node:21-alpine AS web-build
+FROM node:22-alpine AS web-build
 
 WORKDIR /app/web
 
@@ -14,7 +14,7 @@ RUN npm run build
 
 
 ### Download server npm modules
-FROM node:21-alpine AS server-build
+FROM node:22-alpine AS server-build
 
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD="true"
 WORKDIR /app/server
@@ -41,7 +41,7 @@ RUN mv node_modules/googleapis/build/src/apis/docs ./docs && \
 
 
 ### Build final image
-FROM node:21-alpine
+FROM node:22-alpine
 USER root
 
 ENV RUNNING_IN_DOCKER="true"

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,5 +1,5 @@
 ### Build server files
-FROM node:21-alpine AS server-build
+FROM node:22-alpine AS server-build
 
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD="true"
 WORKDIR /app/server
@@ -26,7 +26,7 @@ RUN mv node_modules/googleapis/build/src/apis/docs ./docs && \
 
 
 ### Build final image
-FROM node:21-alpine
+FROM node:22-alpine
 USER root
 
 ENV RUNNING_IN_DOCKER="true"

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:21 AS build
+FROM node:22 AS build
 
 WORKDIR /app/web
 


### PR DESCRIPTION
fix: upgrade Docker Node images from 21 to 22

Update base Node.js images from 21 to 22 across Dockerfiles.

Replaced node:21(-alpine) with node:22(-alpine) in:
- top-level Dockerfile
- server/Dockerfile
- web/Dockerfile

This applies to both build and final stages. No other functional changes were made.

Reason:
The Docker builds were failing because the project still used Node 21 images. Vite no longer supports Node 21 and requires Node 20.19+ or Node 22.12+.

The web build failed with:

  You are using Node.js 21.7.3.
  Vite requires Node.js version 20.19+ or 22.12+.

The unsupported runtime also caused Rolldown/Vite native optional dependency issues, resulting in:

  Cannot find native binding
  Cannot find module '@rolldown/binding-linux-x64-musl'

Switching all Docker build/runtime images to Node 22 ensures dependencies are installed and built in a supported Node.js runtime.