### PR TITLE
fix: handle getProfilePicUrl error for inaccessible WhatsApp chats

### DIFF
--- a/server/src/whatsapp.ts
+++ b/server/src/whatsapp.ts
@@ -50,12 +50,12 @@ export function initWhatsApp(id: string): Client {
       deleteFromCache(id, "purchased");
       try {
         client.destroy();
-      } catch (e) {}
+      } catch (e) { }
       sendEvent(ws, EventType.Redirect, "/contribute?show_error=true");
     }
   });
 
-  client.on("auth_failure", (msg) => {});
+  client.on("auth_failure", (msg) => { });
 
   client.initialize();
   return client;
@@ -79,7 +79,12 @@ export async function downloadFile(
   client: Client,
   whatsappId: string
 ): Promise<Base64 | null> {
-  const photoUrl = await client.getProfilePicUrl(whatsappId);
+  let photoUrl: string | undefined;
+  try {
+    photoUrl = await client.getProfilePicUrl(whatsappId);
+  } catch (e) {
+    return null;
+  }
   if (!photoUrl) return null;
 
   const image = await MessageMedia.fromUrl(photoUrl);


### PR DESCRIPTION
Contacts that exist in the contact list but have no accessible WhatsApp chat (e.g. deleted chats, contacts never messaged) cause whatsapp-web.js to throw an unhandled TypeError inside getProfilePicUrl. This exception propagates uncaught and kills the Node process, aborting the sync.

Wrap the getProfilePicUrl call in a try/catch so inaccessible contacts are silently skipped rather than crashing the server.

Fixes #228
<img width="507" height="310" alt="Screenshot 2026-06-03 111026" src="https://github.com/user-attachments/assets/e0533577-369b-4679-9c9b-83bc56daa4e6" />

