### PR TITLE
feat: add nginx proxy config to web image for separate-container deployment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,20 @@ In order to build the seperate images for the backend and frontend, execute the 
 docker build -t whasync-backend -f server/Dockerfile .
 docker build -t whasync-web -f web/Dockerfile .
 ```
+
+To run them together, create a shared Docker network so the web container can proxy API requests to the backend:
+
+```bash
+docker network create whasync-net
+
+docker run -d --name whasync-backend --network whasync-net --env-file server/.env whasync-backend
+
+# Port 80 (standard):
+docker run -d --name whasync-web --network whasync-net -p 80:80 whasync-web
+
+# Or port 8080:
+docker run -d --name whasync-web --network whasync-net -p 8080:80 whasync-web
+```
+
+The web container's nginx will proxy `/api/` requests to the backend container by its name (`whasync-backend`) on port `8080`.\
+Make sure to add the matching URL (e.g. `http://localhost/api/google_callback` or `http://localhost:8080/api/google_callback`) as an **Authorized Redirect URI** in the Google Cloud Console.

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -18,3 +18,4 @@ FROM nginx:alpine
 EXPOSE 80
 
 COPY --from=build /app/web/dist /usr/share/nginx/html
+COPY web/nginx.conf /etc/nginx/conf.d/default.conf

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -1,0 +1,33 @@
+server {
+    listen 80 default_server;
+    root /usr/share/nginx/html;
+
+    index index.html;
+
+    server_name _;
+
+    # Use Docker's internal DNS resolver; resolve upstream at request time
+    resolver 127.0.0.11 valid=30s;
+    set $backend http://whasync-backend:8080;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /api/ {
+        rewrite ^/api/(.*)$ /$1 break;
+        proxy_pass $backend;
+        proxy_pass_header Authorization;
+        proxy_http_version 1.1;
+        proxy_redirect                     off;
+        proxy_cache_bypass                 $http_upgrade;
+        proxy_set_header Upgrade           $http_upgrade;
+        proxy_set_header Connection        "upgrade";
+        proxy_set_header Host              $http_host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host  $host;
+        proxy_set_header X-Forwarded-Port  $server_port;
+    }
+}


### PR DESCRIPTION
As indicated in PR 271, additional changes was needed for  Google Auth Callback splitting front and backend.

[https://github.com/guyzyl/whatsapp-contact-sync/pull/271](vscode-file://vscode-app/c:/Users/herman.ras/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

## Problem

The `web/Dockerfile` produces a plain nginx image serving only static files.
When running the web and backend containers separately, the frontend makes
relative `/api/` requests that have no proxy target — they 404 immediately.

## Fix

Add `web/nginx.conf` with an `/api/` reverse proxy block that forwards requests
to the backend container by Docker service name (`whasync-backend:8080`).
Uses Docker's embedded DNS resolver (`127.0.0.11`) for lazy resolution so
nginx starts cleanly even if the backend container isn't up yet.

Update `web/Dockerfile` to copy the config into the image.

Update `README.md` with the full `docker network` + `docker run` commands
needed to wire the two containers together.

## Changes

- `web/nginx.conf` — new nginx server block with `/api/` proxy to backend
- `web/Dockerfile` — added `COPY web/nginx.conf /etc/nginx/conf.d/default.conf`
- `README.md` — added separate-image run instructions with Docker network setup

## Tested

```bash
docker network create whasync-net
docker run -d --name whasync-backend --network whasync-net --env-file server/.env whasync-backend
docker run -d --name whasync-web --network whasync-net -p 8080:80 whasync-web
curl http://localhost:8080/api/status
# {"whatsappConnected":false,"googleConnected":false,...}
```
<img width="513" height="484" alt="image" src="https://github.com/user-attachments/assets/fdd67a61-d70a-4b18-a3d6-524602200fff" />
